### PR TITLE
Fix default playbooks for ansible-lint

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,5 +1,4 @@
 ---
-# .ansible-lint
 exclude_paths:
   - .cache/
   - .github/
@@ -8,6 +7,7 @@ exclude_paths:
   - play_tests/
   - meta/
   - galaxy.yml
+  - .ansible-lint
 
 # parseable: true
 # quiet: true
@@ -62,4 +62,4 @@ offline: false
 # List of additional kind:pattern to be added at the top of the default
 # match list, first match determines the file kind.
 kinds:
-  - playbook: "*.{yml,yaml}"
+  - playbook: "docs/examples/*.{yml,yaml}"

--- a/tox.ini
+++ b/tox.ini
@@ -20,18 +20,7 @@ commands =
   black -v -l80 --check plugins
   flake8 plugins
   yamllint -c .yamllint -s .
-  ansible-lint                           \
-      docs/examples/play-claimip.yml     \
-      docs/examples/play-dhcp.yml        \
-      docs/examples/play-dnsrecord.yml   \
-      docs/examples/play-freeip.yml      \
-      docs/examples/play-group.yml       \
-      docs/examples/play-ipinfo.yml      \
-      docs/examples/play-props.yml       \
-      docs/examples/play-role.yml        \
-      docs/examples/play-user.yml        \
-      docs/examples/play-zone.yml        \
-      docs/examples/play_it_all.yml
+  ansible-lint
 
 [testenv:ansible-lint]
 commands =


### PR DESCRIPTION
Changed the `playbook` setting to only include the `docs/examples` directory, so the complete list of all example playbooks could be removed.